### PR TITLE
classes/combine-spdx: Add missing ';'

### DIFF
--- a/classes/combine-spdx.bbclass
+++ b/classes/combine-spdx.bbclass
@@ -1,7 +1,7 @@
 inherit doubleopen-common
 inherit oe-pkgdata-util
 
-IMAGE_POSTPROCESS_COMMAND += "combine_spdx"
+IMAGE_POSTPROCESS_COMMAND += "combine_spdx ;"
 
 python combine_spdx() {
     """


### PR DESCRIPTION
Adds a missing semicolon at the end of IMAGE_POSTPROCESS_COMMAND append.
This prevents subsequent appends from causing errors

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>