### PR TITLE
Add hardknott and honister compatibility

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -10,4 +10,4 @@ BBFILE_PATTERN_doubleopen = "^${LAYERDIR}/"
 BBFILE_PRIORITY_doubleopen = "6"
 
 LAYERDEPENDS_doubleopen = "core"
-LAYERSERIES_COMPAT_doubleopen = "gatesgarth zeus dunfell"
+LAYERSERIES_COMPAT_doubleopen = "gatesgarth zeus dunfell hardknott honister"


### PR DESCRIPTION
Adds compatibility with the hardknott (Yocto 3.3) and honister (Yocto
3.4) releases.

Signed-off-by: Joshua Watt <JPEWhacker@gmail.com>